### PR TITLE
Fixed the implementation of the agenda delete function

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -15,10 +15,24 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+  
+  def destroy
+   @agenda = Agenda.find(params[:id])
+   destroy_agenda = @agenda
+   if @agenda.present?
+      @agenda.destroy
+      team_id = destroy_agenda.team_id
+      team_members = User.where(keep_team_id: team_id)
+      team_members.each do |member|
+        TeamMailer.mail_users(member).deliver
+      end
+      redirect_to dashboard_url,  notice: "The agenda is successfully destroyed and mails are sent to the users"
+   end
   end
 
   private

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -1,0 +1,5 @@
+class TeamMailer < ApplicationMailer
+  def mail_users(user)
+     mail(to: user.email, subject: `The agenda you were in has been deleted`)
+ end
+end

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -28,18 +28,23 @@
     <!-- Sidebar Menu -->
     <nav class="mt-2">
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-        <% @working_team.agendas.each do |agenda| %>
-          <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
-              <p>
-                <%= agenda.title %>
-                <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
-            <ul class="nav nav-treeview" style="display: block;">
-              <% agenda.articles.each do |article| %>
-                <li class="nav-item">
+              <% @working_team.agendas.each do |agenda| %>
+                <li class="nav-item has-treeview menu-open">
+                  <a href="#" class="nav-link">
+                  <div class="nav-link bg-secondary">
+                    <i class="fa fa-circle-o nav-icon"></i>
+                    <p>
+                      <%= agenda.title %>
+                      <% if current_user.id == @working_team.owner_id || current_user.id == agenda.user_id %>
+                        <%= link_to I18n.t('views.button.delete'), agenda, method: :delete, data: { confirm: 'Are you sure you want to delete this agenda?' }%>
+                      <%end%>
+                      <i class="right fa fa-angle-left"></i>
+                    </p>
+                  </a>
+                  </div>
+                  <ul class="nav nav-treeview" style="display: block;">
+                    <% agenda.articles.each do |article| %>
+                      <li class="nav-item">
                   <%= link_to article_path(article), class: 'nav-link' do %>
                     <p><%= article.title %></p>
                   <% end %>

--- a/app/views/team_mailer/mail_users.html.erb
+++ b/app/views/team_mailer/mail_users.html.erb
@@ -1,0 +1,1 @@
+<p>The agenda you were in has been destroyed. This mail is a confirmation<p>

--- a/spec/mailers/previews/team_mailer_preview.rb
+++ b/spec/mailers/previews/team_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_mailer
+class TeamMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_mailer_spec.rb
+++ b/spec/mailers/team_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Fixed the following requirements:
Added the destroy action of Agendas Controller.
Created a delete button in the right part of Agenda name and pressed that button to delete Agenda.
Agenda articles associated with Agenda is also deleted.
Agenda can only be deleted by the creator of the Agenda or the creator (owner) of the team associated with the Agenda.
When an agenda is deleted, a notification email is sent to all users on the team associated with that agenda. 