### PR TITLE
issues 2 & 3

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -4,20 +4,23 @@ class AssignsController < ApplicationController
   before_action :user_exist?, only: [:create]
 
   def create
-    team = find_team(params[:team_id])
-    user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
-    if user
-      team.invite_member(user)
-      redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+    team = Team.friendly.find(params[:team_id])
+    if User.where(email: assign_params).any?
+         user = email_reliable?(assign_params) ? User.find_or_create_by_email(assign_params) : nil
+         if user
+           team.invite_member(user)
+           redirect_to team_url(team), notice: I18n.t('views.messages.assigned')
+         else
+           redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
+         end
     else
-      redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
+      redirect_to team_url(team), notice: I18n.t('views.messages.enter_proper_user')
     end
   end
 
   def destroy
     assign = Assign.find(params[:id])
     destroy_message = assign_destroy(assign, assign.user)
-
     redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,8 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
-  before_action:set_team,only: %i[showeditupdatedestroygive_authority]
-
+  before_action:set_team,only: %i[show edit update destroy give_authority]
 
   def index
     @teams = Team.all

--- a/app/mailers/team_owner_mailer.rb
+++ b/app/mailers/team_owner_mailer.rb
@@ -1,0 +1,5 @@
+class TeamOwnerMailer < ApplicationMailer
+  def mail_new_owner(owner)
+    mail(to: owner, subject: `You are the new team owner, this email confirms it.`)
+  end
+end

--- a/app/views/team_owner_mailer/mail_new_owner.html.erb
+++ b/app/views/team_owner_mailer/mail_new_owner.html.erb
@@ -1,0 +1,1 @@
+<p>You are the new team owner, this email confirms it.</p>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.id == @team.owner_id %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+              <% end %>
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,15 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <%if current_user.id == @team.owner_id && assign.user_id != @team.owner_id %>
+                       <td><%= link_to I18n.t("views.button.transfer_authority"), give_authority_team_path(assign: assign), method: :patch, class: 'btn btn-sm btn-primary' %></td>
+                      <%else%>
+                      <%end%>
+
+                      <% if current_user.id == @team.owner_id || current_user.id == assign.user_id %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                       <%end%>
+
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Keijiban
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.time_zone = 'Asia/Tokyo'
-    config.i18n.default_locale = :ja
+    config.i18n.default_locale = :en
 
     config.generators do |g|
       g.test_framework       :rspec, view_specs: false, helper_specs: false, fixture: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -215,6 +215,10 @@ en:
     pm: pm
   views:
     messages:
+      failed_to_transfer_authority: 'Failed To Transfer Auhtority'
+      transfer_authority: 'Transfer Auhtority'
+      only_team_owner: 'Only the theam owner can perform that'
+      enter_proper_user: 'The user you entered doesnt exist'
       create_agenda: 'Successfully created an agenda!'
       create_article: 'Successfully created an article!'
       update_article: 'Successfully updated the article!'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,7 +216,6 @@ en:
   views:
     messages:
       failed_to_transfer_authority: 'Failed To Transfer Auhtority'
-      transfer_authority: 'Transfer Auhtority'
       only_team_owner: 'Only the theam owner can perform that'
       enter_proper_user: 'The user you entered doesnt exist'
       create_agenda: 'Successfully created an agenda!'
@@ -268,6 +267,7 @@ en:
       team_you_belong_to: 'The team you belong to'
       posted_articles: 'List of posted articles'
     button:
+      transfer_authority: 'Transfer Auhtority'
       submit: 'Submit'
       edit: 'Edit'
       delete: 'Delete'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -256,8 +256,9 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       failed_to_transfer_authority : ' Could not transfer authority '
-      transfer_authority : ' delegation of authority '
+
     button:
+      transfer_authority : ' delegation of authority '
       submit: '投稿'
       edit: '編集'
       delete: '削除'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,6 +205,8 @@ ja:
     pm: 午後
   views:
     messages:
+      only_team_owner : 'チームオーナーのみが操作を実行できます'
+      enter_proper_user : '入力したユーザーは存在しません'
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
@@ -253,6 +255,8 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      failed_to_transfer_authority : ' Could not transfer authority '
+      transfer_authority : ' delegation of authority '
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,11 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
+    member do
+      patch :give_authority
+    end
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do
@@ -17,6 +20,5 @@ Rails.application.routes.draw do
       end
     end
   end
-
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/spec/mailers/previews/team_owner_mailer_preview.rb
+++ b/spec/mailers/previews/team_owner_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_owner_mailer
+class TeamOwnerMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_owner_mailer_spec.rb
+++ b/spec/mailers/team_owner_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamOwnerMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Worked on the following:

When the leader (owner) of the team goes to the team show page, a "Give authority" button appears right next to the "delete" button of each team members.
Pressing that button changes the leader to the user selected by the team leader.
Add any action into Team Controller to implement "Transfer authority".
When a team leader is changed, a notification email will be sent to the new leader.
After the processing is completed, jump to the show page of that team (that is, redirect to the same place)
No other suspicious points or errors in application behavior.

Add the destroy action of AgendasController and then add function to it.
Create a delete button in the right part of Agenda name and press that button to delete Agenda.
Agenda articles associated with Agenda is also deleted.
Agenda can only be deleted by the creator of the Agenda or the creator (owner) of the team associated with the Agenda.
When an agenda is deleted, a notification email is sent to all users on the team associated with that agenda. Go to DashBoard after the processing is complete.
check the behavior of the application.